### PR TITLE
Changed build message in the Log Section.

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-backpack/admin/console/components/build/clientlibs/js/build.js
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-backpack/admin/console/components/build/clientlibs/js/build.js
@@ -256,7 +256,7 @@ $(function () {
                         $.each(data.log, function (index, value) {
                             $buildLog.append('<div>' + value + '</div>');
                         });
-                        $buildLog.append('<h4>Approximate size of the assets in the package: ' + bytesToSize(data.dataSize) + '</h4>');
+                        $buildLog.append(<h4>There are no assets in the package</h4>);
                         scrollLog();
                     }
                 } else {


### PR DESCRIPTION
Changed build message in the Log Section from 'Approximate size of the assets in the package: 0 Bytes' to 'There are no assets in the package'.